### PR TITLE
fix sitemap URLs to use trailing slashes

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,12 +3,18 @@ import { source } from "@/lib/source";
 
 const baseUrl =
   process.env.NEXT_PUBLIC_BASE_URL || "https://www.absmach.eu/docs/hardware";
+const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
+
+function toSiteUrl(path: string): string {
+  const url = `${normalizedBaseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+  return url.endsWith("/") ? url : `${url}/`;
+}
 
 export const dynamic = "force-static";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return source.getPages().map((page) => ({
-    url: `${baseUrl}${page.url}`,
+    url: toSiteUrl(page.url),
     lastModified: new Date().toISOString(),
     changeFrequency: "weekly",
     priority: 0.7,


### PR DESCRIPTION
Updates generated sitemap URLs so page entries use trailing slashes and avoid redirecting canonical URLs.\n\nVerification:\n- pnpm lint (fails on existing .claude/settings.local.json formatting)\n- pnpm types:check (fails on existing Next type/dependency errors)\n- pnpm build (fails on existing Next type/dependency errors)